### PR TITLE
Create sprint plan

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,12 @@
+# Code Review
+
+## Engineer Review
+- `ruff check .` passed with no issues.
+- `bandit -r src -q` returned no vulnerabilities.
+- No obvious performance issues or nested loops detected in the current codebase.
+
+## Product Manager Review
+- Acceptance criteria in `tests/sprint_acceptance_criteria.json` are covered by `tests/test_foundational.py`.
+- Running `pip install -e .` followed by `pytest -q` yields all tests passing.
+
+All checks passed.

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,0 +1,13 @@
+# Development Plan
+
+## Phase 1: Foundational Setup
+- [ ] **Foundational:** Establish a testing framework (`pytest`, etc.) with initial tests.
+
+## Phase 2: Core Feature Implementation
+- [ ] **Feature:** Implement core API endpoints as described in the README.
+
+## Phase 3: Review & Refinement
+
+
+## Completed Tasks
+

--- a/SPRINT_BOARD.md
+++ b/SPRINT_BOARD.md
@@ -1,0 +1,6 @@
+# Sprint Board
+
+## Backlog
+| Task | Owner | Priority | Status |
+| --- | --- | --- | --- |
+| Establish a testing framework (`pytest`, etc.) with initial tests. | @agent | P0 | Done |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "slack-kb-agent"
+version = "0.1.0"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["slack_kb_agent"]

--- a/src/slack_kb_agent/__init__.py
+++ b/src/slack_kb_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Slack Knowledge Base Agent package."""
+
+from .utils import add
+
+__all__ = ["add"]

--- a/src/slack_kb_agent/utils.py
+++ b/src/slack_kb_agent/utils.py
@@ -1,0 +1,8 @@
+"""Utility functions for slack_kb_agent."""
+
+from typing import Optional
+
+
+def add(a: Optional[int], b: Optional[int]) -> int:
+    """Return the sum of ``a`` and ``b`` treating ``None`` as ``0``."""
+    return (a or 0) + (b or 0)

--- a/tests/sprint_acceptance_criteria.json
+++ b/tests/sprint_acceptance_criteria.json
@@ -1,0 +1,10 @@
+{
+  "establish-a-testing-framework-(`pytest`,-etc.)-with-initial-tests.": {
+    "test_file": "tests/test_foundational.py",
+    "description": "Verifies that Establish a testing framework (`pytest`, etc.) with initial tests.",
+    "cases": {
+      "success": "Asserts the primary success case.",
+      "edge_case_null_input": "Asserts that providing null input is handled gracefully."
+    }
+  }
+}

--- a/tests/test_foundational.py
+++ b/tests/test_foundational.py
@@ -1,0 +1,9 @@
+from slack_kb_agent import add
+
+
+def test_success():
+    assert add(1, 2) == 3
+
+
+def test_edge_case_null_input():
+    assert add(None, None) == 0


### PR DESCRIPTION
## Summary
- establish minimal pytest framework via pyproject
- add sample util function and tests
- mark sprint task done
- add code review report

## Testing
- `ruff check .`
- `bandit -r src -q`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685871237a0883299d25ca40839e1c2d

## Summary by Sourcery

Set up initial project scaffolding by configuring packaging, adding a basic utility function with tests, and documenting sprint planning and code review results.

New Features:
- Add an `add` utility function that sums two optional integers treating `None` as zero

Enhancements:
- Establish a pytest-based testing framework with initial sample tests

Build:
- Configure project packaging with setuptools via pyproject.toml

Documentation:
- Add development plan, sprint board, and code review documentation files

Tests:
- Include foundational tests for the `add` function and sprint acceptance criteria JSON