### PR TITLE
Release v1.2.0

### DIFF
--- a/API_USAGE_GUIDE.md
+++ b/API_USAGE_GUIDE.md
@@ -1,0 +1,62 @@
+# API Usage Guide
+
+This guide provides examples for interacting with the `slack_kb_agent` package programmatically.
+
+## Querying the Knowledge Base
+
+```python
+from slack_kb_agent import KnowledgeBase, QueryProcessor, UsageAnalytics, Query
+
+kb = KnowledgeBase()
+# ... load documents or add sources ...
+analytics = UsageAnalytics()
+processor = QueryProcessor(kb, analytics=analytics)
+
+results = processor.process_query(Query(text="deployment process", user="U1"))
+for doc in results:
+    print(doc.content)
+```
+
+## Routing Unanswered Questions
+
+```python
+from slack_kb_agent import RoutingEngine, TeamMember
+
+members = [TeamMember(id="U1", name="Alice", expertise=["backend"])]
+router = RoutingEngine(members)
+processor = QueryProcessor(kb, routing=router)
+
+_, experts = processor.search_and_route("backend issue")
+if experts:
+    print("Escalate to", experts[0].name)
+```
+
+## Accessing Usage Analytics
+
+```python
+# After processing queries
+print("Top queries:", analytics.top_queries())
+print("Top users:", analytics.top_users())
+print("Top channels:", analytics.top_channels())
+
+# Persist analytics to a file
+analytics.save("analytics.json")
+
+# Load analytics later
+loaded = UsageAnalytics.load("analytics.json")
+```
+
+## Persisting the Knowledge Base
+
+```python
+kb.save("kb.json")
+loaded_kb = KnowledgeBase.load("kb.json")
+```
+
+## Command Line Usage
+
+```bash
+$ slack-kb-agent "search term" --kb kb.json --analytics analytics.json
+```
+
+For more details on configuration and deployment, see `README.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## v1.2.0 - 2025-06-27
+
+- feat(cli): add command line interface for querying the knowledge base
+- docs: document CLI usage in README and API guide
+- tests: cover CLI functionality
+
+## v1.1.0 - 2025-06-27
+
+- feat(kb): allow saving and loading knowledge base documents
+- docs: note knowledge base persistence in README and API guide
+- tests: add coverage for knowledge base persistence
+
+## v1.0.1 - 2025-06-27
+
+- feat(analytics): allow saving and loading analytics from JSON
+- docs: mention analytics persistence in README and API guide
+- tests: cover analytics persistence
+
+## v1.0.0 - 2025-06-27
+
+- first stable release with analytics and smart routing
+- docs: API usage guide and README updates
+
+
+## v0.0.7 - 2025-06-27
+
+- docs: add API usage guide and reference from README
+
+## v0.0.6 - 2025-06-27
+
+- feat(analytics): track query counts per channel via ``UsageAnalytics.top_channels``
+- docs: mention channel tracking in README
+
+## v0.0.5 - 2025-06-27
+
+- feat(analytics): track query counts per user via ``UsageAnalytics.top_users``
+- docs: mention analytics now reports active users
+
+## v0.0.4 - 2025-06-27
+
+- feat(analytics): integrate ``UsageAnalytics`` with ``QueryProcessor``
+
+## v0.0.3 - 2025-06-26
+
+- feat(analytics): add simple UsageAnalytics module
+- docs: mention analytics in README
+
 ## v0.0.2 - 2025-06-25
 
 - Applying previous commit. (0d0571f)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Slack-KB-Agent
 
+Current version: 1.2.0
+
 Intelligent Slack bot that answers team questions by indexing and searching across documentation, GitHub issues, code comments, and conversation history.
 
 ## Features
@@ -8,7 +10,11 @@ Intelligent Slack bot that answers team questions by indexing and searching acro
 - **Contextual Q&A**: Understands team-specific terminology and project context
 - **Real-time Learning**: Continuously updates knowledge base from ongoing conversations
 - **Smart Routing**: Escalates complex questions to appropriate team members
-- **Usage Analytics**: Tracks common questions and knowledge gaps
+- **Usage Analytics**: Tracks common questions, knowledge gaps, active users, and active channels
+  (powered by the `UsageAnalytics` module integrated with the `QueryProcessor`)
+- **Analytics Persistence**: Save and load usage statistics from JSON files
+- **Knowledge Base Persistence**: Save and load indexed documents from JSON files
+- **Command Line Interface**: Query the knowledge base using the `slack-kb-agent` CLI
 - **Permission-Aware**: Respects access controls and sensitive information boundaries
 
 ## Quick Setup
@@ -67,6 +73,12 @@ docker-compose up -d
 - `/kb add <url>` - Add documentation URL to index
 - `/kb stats` - Show usage statistics
 - `/kb feedback <rating>` - Rate last response
+- See [API_USAGE_GUIDE.md](API_USAGE_GUIDE.md) for programmatic examples
+
+### CLI
+```bash
+$ slack-kb-agent "deployment process" --kb kb.json
+```
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slack_kb_agent"
-version = "0.0.2"
+version = "1.2.0"
+
+[project.scripts]
+slack-kb-agent = "slack_kb_agent.cli:main"
 requires-python = ">=3.8"
 
 [tool.setuptools]

--- a/src/slack_kb_agent/__init__.py
+++ b/src/slack_kb_agent/__init__.py
@@ -1,5 +1,7 @@
 """Slack Knowledge Base Agent package."""
 
+__version__ = "1.2.0"
+
 from .utils import add
 from .models import Document
 from .sources import (
@@ -14,6 +16,8 @@ from .query_processor import Query, QueryProcessor
 from .real_time import RealTimeUpdater
 from .smart_routing import RoutingEngine, TeamMember, load_team_profiles
 from .escalation import SlackNotifier
+from .analytics import UsageAnalytics
+from . import cli
 
 __all__ = [
     "add",
@@ -31,4 +35,6 @@ __all__ = [
     "TeamMember",
     "load_team_profiles",
     "SlackNotifier",
+    "UsageAnalytics",
+    "cli",
 ]

--- a/src/slack_kb_agent/analytics.py
+++ b/src/slack_kb_agent/analytics.py
@@ -1,0 +1,86 @@
+"""Simple usage analytics for tracking query frequency."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+from typing import List, Tuple
+
+
+@dataclass
+class UsageAnalytics:
+    """Collect and report query statistics."""
+
+    counts: Counter[str] = field(default_factory=Counter)
+    user_counts: Counter[str] = field(default_factory=Counter)
+    channel_counts: Counter[str] = field(default_factory=Counter)
+
+    def record_query(
+        self, query: str, *, user: str | None = None, channel: str | None = None
+    ) -> None:
+        """Record a user query for analytics."""
+        normalized = query.lower().strip()
+        if normalized:
+            self.counts[normalized] += 1
+            if user:
+                self.user_counts[user] += 1
+            if channel:
+                self.channel_counts[channel] += 1
+
+    def top_queries(self, n: int = 5) -> List[Tuple[str, int]]:
+        """Return the ``n`` most common queries."""
+        return self.counts.most_common(n)
+
+    def top_users(self, n: int = 5) -> List[Tuple[str, int]]:
+        """Return the ``n`` most active users."""
+        return self.user_counts.most_common(n)
+
+    def top_channels(self, n: int = 5) -> List[Tuple[str, int]]:
+        """Return the ``n`` most active channels."""
+        return self.channel_counts.most_common(n)
+
+    def reset(self) -> None:
+        """Clear all recorded statistics."""
+        self.counts.clear()
+        self.user_counts.clear()
+        self.channel_counts.clear()
+
+    # Persistence helpers -------------------------------------------------
+
+    def to_dict(self) -> dict[str, dict[str, int]]:
+        """Return a serializable representation of analytics data."""
+        return {
+            "counts": dict(self.counts),
+            "user_counts": dict(self.user_counts),
+            "channel_counts": dict(self.channel_counts),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, dict[str, int]]) -> "UsageAnalytics":
+        """Create a :class:`UsageAnalytics` instance from a dictionary."""
+        ua = cls()
+        ua.counts.update(data.get("counts", {}))
+        ua.user_counts.update(data.get("user_counts", {}))
+        ua.channel_counts.update(data.get("channel_counts", {}))
+        return ua
+
+    def save(self, path: str | Path) -> None:
+        """Persist analytics data to ``path`` as JSON."""
+        Path(path).write_text(json.dumps(self.to_dict()), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> "UsageAnalytics":
+        """Load analytics data from ``path`` returning a new instance."""
+        try:
+            text = Path(path).read_text(encoding="utf-8")
+        except OSError:
+            return cls()
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return cls()
+        if not isinstance(data, dict):
+            return cls()
+        return cls.from_dict(data)

--- a/src/slack_kb_agent/cli.py
+++ b/src/slack_kb_agent/cli.py
@@ -1,0 +1,33 @@
+import argparse
+from pathlib import Path
+
+from .knowledge_base import KnowledgeBase
+from .analytics import UsageAnalytics
+from .query_processor import QueryProcessor, Query
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Command line interface for querying the knowledge base."""
+    parser = argparse.ArgumentParser(description="Query the Slack knowledge base")
+    parser.add_argument("query", help="Query text")
+    parser.add_argument("--kb", default="kb.json", help="Path to knowledge base JSON")
+    parser.add_argument("--analytics", default="analytics.json", help="Path to analytics JSON")
+    parser.add_argument("--user", help="User ID")
+    parser.add_argument("--channel", help="Channel ID")
+    args = parser.parse_args(argv)
+
+    kb = KnowledgeBase.load(Path(args.kb))
+    analytics = UsageAnalytics.load(Path(args.analytics))
+    processor = QueryProcessor(kb, analytics=analytics)
+
+    docs = processor.process_query(
+        Query(text=args.query, user=args.user, channel=args.channel)
+    )
+    for doc in docs:
+        print(doc.content)
+
+    analytics.save(Path(args.analytics))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/slack_kb_agent/knowledge_base.py
+++ b/src/slack_kb_agent/knowledge_base.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from typing import List
+import json
+from dataclasses import asdict
+from pathlib import Path
 
 from .models import Document
 from .sources import BaseSource
@@ -36,3 +39,38 @@ class KnowledgeBase:
         """Return documents containing the query string."""
         q = query.lower()
         return [doc for doc in self.documents if q in doc.content.lower()]
+
+    # Persistence helpers -------------------------------------------------
+
+    def to_dict(self) -> dict[str, list[dict]]:
+        """Return a serializable representation of all documents."""
+        return {"documents": [asdict(d) for d in self.documents]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, list[dict]]) -> "KnowledgeBase":
+        """Create a knowledge base from a dictionary."""
+        kb = cls()
+        for item in data.get("documents", []):
+            if not isinstance(item, dict):
+                continue
+            kb.add_document(Document(**item))
+        return kb
+
+    def save(self, path: str | Path) -> None:
+        """Persist documents to ``path`` as JSON."""
+        Path(path).write_text(json.dumps(self.to_dict()), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> "KnowledgeBase":
+        """Load documents from ``path`` and return a new knowledge base."""
+        try:
+            text = Path(path).read_text(encoding="utf-8")
+        except OSError:
+            return cls()
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return cls()
+        if not isinstance(data, dict):
+            return cls()
+        return cls.from_dict(data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+from slack_kb_agent.knowledge_base import KnowledgeBase
+from slack_kb_agent.models import Document
+from slack_kb_agent import cli
+
+
+def test_cli_search(tmp_path, capsys):
+    kb = KnowledgeBase()
+    kb.add_document(Document(content="hello world", source="manual"))
+    kb_path = tmp_path / "kb.json"
+    ua_path = tmp_path / "ua.json"
+    kb.save(kb_path)
+
+    cli.main(["hello", "--kb", str(kb_path), "--analytics", str(ua_path)])
+
+    out = capsys.readouterr().out
+    assert "hello world" in out
+    assert ua_path.exists()

--- a/tests/test_foundational.py
+++ b/tests/test_foundational.py
@@ -7,3 +7,9 @@ def test_success():
 
 def test_edge_case_null_input():
     assert add(None, None) == 0
+
+
+def test_version_constant():
+    from slack_kb_agent import __version__
+
+    assert __version__ == "1.2.0"

--- a/tests/test_kb_persistence.py
+++ b/tests/test_kb_persistence.py
@@ -1,0 +1,20 @@
+from slack_kb_agent.knowledge_base import KnowledgeBase
+from slack_kb_agent.models import Document
+
+
+def test_save_and_load(tmp_path):
+    kb = KnowledgeBase()
+    kb.add_document(Document(content="hi", source="manual"))
+    path = tmp_path / "kb.json"
+    kb.save(path)
+
+    loaded = KnowledgeBase.load(path)
+    assert len(loaded.documents) == 1
+    assert loaded.documents[0].content == "hi"
+
+
+def test_load_missing_file(tmp_path):
+    path = tmp_path / "missing.json"
+    kb = KnowledgeBase.load(path)
+    assert kb.documents == []
+

--- a/tests/test_usage_analytics.py
+++ b/tests/test_usage_analytics.py
@@ -1,0 +1,62 @@
+from slack_kb_agent.analytics import UsageAnalytics
+from slack_kb_agent.query_processor import QueryProcessor, Query
+from slack_kb_agent.knowledge_base import KnowledgeBase
+
+
+def test_record_and_top_queries():
+    ua = UsageAnalytics()
+    ua.record_query("Hello")
+    ua.record_query("Hello")
+    ua.record_query("World")
+
+    top = ua.top_queries(2)
+    assert top[0] == ("hello", 2)
+    assert ("world", 1) in top
+
+
+def test_reset_clears_counts():
+    ua = UsageAnalytics()
+    ua.record_query("something")
+    ua.reset()
+    assert ua.top_queries() == []
+
+
+def test_top_users():
+    ua = UsageAnalytics()
+    ua.record_query("hi", user="U1")
+    ua.record_query("yo", user="U1")
+    ua.record_query("yo", user="U2")
+
+    assert ua.top_users(1) == [("U1", 2)]
+
+
+def test_top_channels():
+    ua = UsageAnalytics()
+    ua.record_query("hi", channel="C1")
+    ua.record_query("yo", channel="C1")
+    ua.record_query("yo", channel="C2")
+
+    assert ua.top_channels(1) == [("C1", 2)]
+
+
+def test_processor_records_queries():
+    kb = KnowledgeBase()
+    ua = UsageAnalytics()
+    qp = QueryProcessor(kb, analytics=ua)
+    qp.process_query(Query(text="Hello", user="U1", channel="C1"))
+
+    assert ua.top_queries() == [("hello", 1)]
+    assert ua.top_users() == [("U1", 1)]
+    assert ua.top_channels() == [("C1", 1)]
+
+
+def test_save_and_load(tmp_path):
+    ua = UsageAnalytics()
+    ua.record_query("hi", user="U1", channel="C1")
+    path = tmp_path / "ua.json"
+    ua.save(path)
+
+    loaded = UsageAnalytics.load(path)
+    assert loaded.top_queries() == [("hi", 1)]
+    assert loaded.top_users() == [("U1", 1)]
+    assert loaded.top_channels() == [("C1", 1)]


### PR DESCRIPTION
## Summary
- add `slack-kb-agent` CLI for searching a persisted knowledge base
- document CLI usage in README and API usage guide
- bump version to 1.2.0 and note in changelog
- add tests covering CLI functionality

## Testing
- `ruff check .`
- `bandit -r src -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e881b92348329975da35ce2f47a16

## Summary by Sourcery

Release version 1.2.0: introduce a command-line interface, integrate and persist usage analytics, add persistence for the knowledge base, update documentation, and include comprehensive tests.

New Features:
- Add `slack-kb-agent` CLI for querying the knowledge base with persisted analytics

Enhancements:
- Integrate `UsageAnalytics` into `QueryProcessor` for recording and reporting query metrics
- Add JSON persistence helpers for both `KnowledgeBase` and `UsageAnalytics` modules
- Expose CLI and analytics components in package exports and add script entry point

Documentation:
- Update README with current version, CLI usage, and new persistence features
- Add `API_USAGE_GUIDE.md` with programmatic and CLI usage examples

Tests:
- Add tests for CLI behavior, knowledge base persistence, usage analytics, and version constant

Chores:
- Bump package version to 1.2.0 and update CHANGELOG